### PR TITLE
Removed hard-coded prefix from environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -48,4 +48,3 @@ dependencies:
       - tqdm==4.66.2
       - typing-extensions==4.7.1
       - xgboost==0.90
-prefix: /home/javan/anaconda3/envs/oc2


### PR DESCRIPTION
This pull request removes the hard-coded prefix path in the `environment.yml` file. This should prevent the environment installation from failing when running `conda env create -f environment.yml` as mentioned in the README.

Fixes #1 